### PR TITLE
Add lead capture form to About page

### DIFF
--- a/beginner-react-webapp/src/AboutPage.js
+++ b/beginner-react-webapp/src/AboutPage.js
@@ -1,14 +1,103 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
+import { submitLead } from './services/leads';
 
 function AboutPage() {
+  const [formData, setFormData] = useState({
+    name: '',
+    email: '',
+    goals: '',
+  });
+  const [status, setStatus] = useState({ type: 'idle', message: '' });
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setIsSubmitting(true);
+    setStatus({ type: 'loading', message: '' });
+
+    try {
+      await submitLead(formData);
+      setStatus({
+        type: 'success',
+        message: 'Merci ! Nous vous enverrons votre programme personnalisé très bientôt.',
+      });
+      setFormData({ name: '', email: '', goals: '' });
+    } catch (error) {
+      setStatus({
+        type: 'error',
+        message:
+          "Oups, une erreur est survenue. Merci de réessayer plus tard ou de nous contacter directement.",
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
   return (
     <div>
-      <h1>About This App</h1>
-      <p>This is the About Page. Here you can learn more about this app.</p>
-      <p>This application is part of a larger project to learn coding across multiple platforms.</p>
+      <h1>À propos de CodingLearn</h1>
+      <p>
+        Cette page présente notre accompagnement. Partagez vos objectifs pour recevoir un programme
+        d'apprentissage adapté directement dans votre boîte mail.
+      </p>
+
+      <form onSubmit={handleSubmit} aria-label="Formulaire de contact">
+        <div>
+          <label htmlFor="name">Nom</label>
+          <input
+            id="name"
+            name="name"
+            type="text"
+            value={formData.name}
+            onChange={handleChange}
+            required
+          />
+        </div>
+
+        <div>
+          <label htmlFor="email">Email</label>
+          <input
+            id="email"
+            name="email"
+            type="email"
+            value={formData.email}
+            onChange={handleChange}
+            required
+          />
+        </div>
+
+        <div>
+          <label htmlFor="goals">Objectifs</label>
+          <textarea
+            id="goals"
+            name="goals"
+            value={formData.goals}
+            onChange={handleChange}
+            rows="4"
+            required
+          />
+        </div>
+
+        <button type="submit" disabled={isSubmitting}>
+          {isSubmitting ? 'Envoi en cours…' : 'Recevoir le programme'}
+        </button>
+      </form>
+
+      {status.type === 'success' && <p role="status">{status.message}</p>}
+      {status.type === 'error' && (
+        <p role="alert" style={{ color: 'red' }}>
+          {status.message}
+        </p>
+      )}
+
       <Link to="/">
-        <button>Go to Home Page</button>
+        <button type="button">Retour à l'accueil</button>
       </Link>
     </div>
   );

--- a/beginner-react-webapp/src/App.test.js
+++ b/beginner-react-webapp/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test("affiche l'accueil par défaut", () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByRole('heading', { name: /welcome to my first web app!/i });
+  expect(heading).toBeInTheDocument();
 });

--- a/beginner-react-webapp/src/__tests__/AboutPage.test.js
+++ b/beginner-react-webapp/src/__tests__/AboutPage.test.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import AboutPage from '../AboutPage';
+import * as leadsService from '../services/leads';
+
+describe('AboutPage', () => {
+  const renderComponent = () =>
+    render(
+      <MemoryRouter>
+        <AboutPage />
+      </MemoryRouter>
+    );
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('envoie le formulaire et affiche un message de succès', async () => {
+    jest.spyOn(leadsService, 'submitLead').mockResolvedValueOnce({ status: 'ok' });
+
+    renderComponent();
+
+    fireEvent.change(screen.getByLabelText(/nom/i), { target: { value: 'Ada Lovelace' } });
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'ada@example.com' } });
+    fireEvent.change(screen.getByLabelText(/objectifs/i), { target: { value: 'Découvrir React' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /recevoir le programme/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toHaveTextContent(/merci/i);
+    });
+
+    expect(leadsService.submitLead).toHaveBeenCalledWith({
+      name: 'Ada Lovelace',
+      email: 'ada@example.com',
+      goals: 'Découvrir React',
+    });
+  });
+
+  it('affiche un message d\'erreur si la soumission échoue', async () => {
+    jest.spyOn(leadsService, 'submitLead').mockRejectedValueOnce(new Error('Erreur réseau'));
+
+    renderComponent();
+
+    fireEvent.change(screen.getByLabelText(/nom/i), { target: { value: 'Grace Hopper' } });
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'grace@example.com' } });
+    fireEvent.change(screen.getByLabelText(/objectifs/i), {
+      target: { value: 'Approfondir JavaScript' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /recevoir le programme/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/erreur est survenue/i);
+    });
+  });
+});

--- a/beginner-react-webapp/src/services/leads.js
+++ b/beginner-react-webapp/src/services/leads.js
@@ -1,0 +1,25 @@
+const DELAY_MS = 400;
+
+/**
+ * Envoie les informations de lead vers notre CRM.
+ * @param {{name: string, email: string, goals: string}} lead
+ * @returns {Promise<{status: 'ok'}>}
+ */
+export function submitLead(lead) {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      if (!lead || !lead.email) {
+        reject(new Error('Email manquant'));
+        return;
+      }
+
+      // Mock : on simule la persistance locale en journalisant dans la console.
+      // Dans une vraie application, on ferait un appel fetch/axios ici.
+      // eslint-disable-next-line no-console
+      console.info('Lead enregistré', lead);
+      resolve({ status: 'ok' });
+    }, DELAY_MS);
+  });
+}
+
+export default submitLead;

--- a/beginner-react-webapp/src/setupTests.js
+++ b/beginner-react-webapp/src/setupTests.js
@@ -3,3 +3,27 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+
+jest.mock(
+  'react-router-dom',
+  () => {
+    const React = require('react');
+
+    const PassThrough = ({ children }) => <div>{children}</div>;
+
+    return {
+      __esModule: true,
+      Link: ({ to, children, ...rest }) => (
+        <a href={typeof to === 'string' ? to : '#'} {...rest}>
+          {children}
+        </a>
+      ),
+      MemoryRouter: PassThrough,
+      BrowserRouter: PassThrough,
+      Routes: PassThrough,
+      Route: ({ element }) => element,
+      useNavigate: () => () => {},
+    };
+  },
+  { virtual: true }
+);


### PR DESCRIPTION
## Summary
- add a lead capture form with validation and feedback to the About page
- create a mock CRM submission service and supporting router test mock
- add unit tests covering success and error cases and refresh the App smoke test

## Testing
- CI=true npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68daf85957c4833386a38afb38b66328