### PR TITLE
Fix pricing tier CTA styling

### DIFF
--- a/beginner-react-webapp/src/App.css
+++ b/beginner-react-webapp/src/App.css
@@ -59,7 +59,7 @@ button {
 }
 
 a {
-  color: inherit;
+  color: #0066ff;
   text-decoration: none;
 }
 
@@ -289,21 +289,12 @@ a:hover {
   font-weight: 600;
   cursor: pointer;
 
-  border-radius: 5px;
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  transition: background-color 0.2s ease, transform 0.2s ease;
 }
 
 button:hover {
   transform: translateY(-1px);
   box-shadow: 0 6px 14px rgba(0, 102, 255, 0.25);
-}
-
-a {
-  color: #0066ff;
-  text-decoration: none;
-}
-
-  transition: background-color 0.2s ease, transform 0.2s ease;
 }
 
 .pricing-tier__cta:hover {


### PR DESCRIPTION
## Summary
- consolidate the duplicated anchor styling so links share one definition
- clean up the pricing tier CTA styles by removing duplicate border radius and restoring the background-color transition

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dafe5f37a88333be535d49aa4e3525