### PR TITLE
Integrate CodingLearn logo across navigation and hero

### DIFF
--- a/beginner-react-webapp/src/App.css
+++ b/beginner-react-webapp/src/App.css
@@ -1,11 +1,12 @@
 :root {
-  --color-primary: #4f46e5;
-  --color-primary-dark: #3730a3;
-  --color-background: #f5f5fb;
-  --color-surface: #ffffff;
-  --color-text: #1f2937;
-  --color-muted: #6b7280;
-  --shadow-soft: 0 15px 30px rgba(79, 70, 229, 0.12);
+  --color-primary: #0d3b66;
+  --color-primary-dark: #052446;
+  --color-accent: #f6c143;
+  --color-background: #f7f1df;
+  --color-surface: #fffaf0;
+  --color-text: #0f1f2f;
+  --color-muted: #5f6c7c;
+  --shadow-soft: 0 20px 40px rgba(13, 59, 102, 0.18);
   --radius-lg: 18px;
   --radius-md: 12px;
   --radius-sm: 8px;
@@ -16,17 +17,18 @@
 }
 
 body {
-
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   margin: 0;
   padding: 0;
-  background-color: #f7f8fb;
-  color: #1a1a1a;
+  background-color: var(--color-background);
+  color: var(--color-text);
 }
 
 .App {
   min-height: 100vh;
-  background-color: #f7f8fb;
+  background: radial-gradient(circle at top left, rgba(246, 193, 67, 0.12), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(13, 59, 102, 0.08), transparent 50%),
+    var(--color-background);
 }
 
 main {
@@ -36,7 +38,7 @@ main {
 }
 
 div > h1 {
-  color: #1a1a1a;
+  color: var(--color-primary-dark);
   margin-bottom: 20px;
 }
 
@@ -44,38 +46,38 @@ p {
   font-size: 1.1em;
   line-height: 1.6;
   margin-bottom: 20px;
-  color: #404040;
+  color: var(--color-muted);
 }
 
 button {
   margin: 0;
   font-family: 'Inter', 'Segoe UI', Roboto, sans-serif;
-  background-color: var(--color-primary);
-  color: #ffffff;
+  background: linear-gradient(135deg, var(--color-accent), #f8d46e);
+  color: var(--color-primary-dark);
   border: none;
   border-radius: var(--radius-sm);
   padding: 0.75rem 1.5rem;
   line-height: 1.6;
   font-weight: 600;
   cursor: pointer;
-  transition: background-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+  transition: background 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+  box-shadow: 0 8px 18px rgba(246, 193, 67, 0.25);
 }
 
 button:hover,
 button:focus {
-  background-color: var(--color-primary-dark);
-  color: #ffffff;
+  color: var(--color-primary-dark);
   transform: translateY(-1px);
-  box-shadow: 0 10px 20px rgba(79, 70, 229, 0.25);
+  box-shadow: 0 12px 24px rgba(246, 193, 67, 0.35);
 }
 
 button:focus-visible {
-  outline: 3px solid rgba(79, 70, 229, 0.45);
+  outline: 3px solid rgba(246, 193, 67, 0.6);
   outline-offset: 2px;
 }
 
 button:disabled {
-  background-color: rgba(79, 70, 229, 0.4);
+  background: linear-gradient(135deg, rgba(246, 193, 67, 0.6), rgba(248, 212, 110, 0.6));
   cursor: not-allowed;
   box-shadow: none;
   transform: none;
@@ -83,18 +85,18 @@ button:disabled {
 
 button:disabled:hover,
 button:disabled:focus {
-  background-color: rgba(79, 70, 229, 0.4);
   box-shadow: none;
   transform: none;
 }
 
 a {
-  color: #0066ff;
+  color: var(--color-primary);
   text-decoration: none;
+  font-weight: 600;
 }
 
 a:hover {
-  text-decoration: underline;
+  color: var(--color-accent);
 }
 
 .homepage {
@@ -107,12 +109,42 @@ a:hover {
 }
 
 .hero {
-  background: linear-gradient(135deg, var(--color-primary), var(--color-primary-dark));
+  background: linear-gradient(135deg, rgba(13, 59, 102, 0.95), rgba(5, 36, 70, 0.95));
   color: #ffffff;
   padding: 3.5rem clamp(1.5rem, 4vw, 4rem);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-soft);
   text-align: center;
+  position: relative;
+  overflow: hidden;
+}
+
+.hero::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(246, 193, 67, 0.35), transparent 60%);
+  opacity: 0.9;
+}
+
+.hero > * {
+  position: relative;
+  z-index: 1;
+}
+
+.hero__brand {
+  width: clamp(140px, 24vw, 220px);
+  margin: 0 auto 1.75rem;
+  display: flex;
+  justify-content: center;
+}
+
+.hero__brand img {
+  width: 100%;
+  height: auto;
+  display: block;
+  filter: drop-shadow(0 14px 26px rgba(9, 33, 58, 0.45));
+  border-radius: 18px;
 }
 
 .hero h1 {
@@ -129,19 +161,19 @@ a:hover {
 
 .hero__cta {
   display: inline-block;
-  background-color: #ffffff;
+  background: linear-gradient(135deg, var(--color-accent), #f8d46e);
   color: var(--color-primary-dark);
-  font-weight: 600;
+  font-weight: 700;
   padding: 0.85rem 1.9rem;
   border-radius: 999px;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
-  box-shadow: 0 10px 20px rgba(255, 255, 255, 0.25);
+  box-shadow: 0 12px 22px rgba(246, 193, 67, 0.4);
 }
 
 .hero__cta:hover {
   transform: translateY(-2px);
   text-decoration: none;
-  box-shadow: 0 14px 25px rgba(255, 255, 255, 0.35);
+  box-shadow: 0 16px 28px rgba(246, 193, 67, 0.45);
 }
 
 .section {
@@ -151,15 +183,16 @@ a:hover {
 }
 
 .section--accent {
-  background-color: var(--color-surface);
+  background: linear-gradient(160deg, rgba(255, 250, 240, 0.9), rgba(247, 241, 223, 0.95));
   padding: 3rem clamp(1.5rem, 4vw, 3.5rem);
   border-radius: var(--radius-lg);
-  box-shadow: 0 10px 30px rgba(31, 41, 55, 0.08);
+  box-shadow: 0 18px 38px rgba(13, 59, 102, 0.08);
 }
 
 .section__header h2 {
   font-size: clamp(1.8rem, 3vw, 2.4rem);
   margin: 0 0 0.5rem;
+  color: var(--color-primary-dark);
 }
 
 .section__header p {
@@ -178,16 +211,17 @@ a:hover {
   background-color: var(--color-surface);
   border-radius: var(--radius-md);
   padding: 2rem 1.75rem;
-  box-shadow: 0 8px 20px rgba(79, 70, 229, 0.08);
+  box-shadow: 0 12px 28px rgba(13, 59, 102, 0.1);
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
+  border: 1px solid rgba(13, 59, 102, 0.08);
 }
 
 .feature-card:hover {
   transform: translateY(-4px);
-  box-shadow: 0 18px 35px rgba(79, 70, 229, 0.12);
+  box-shadow: 0 20px 36px rgba(13, 59, 102, 0.16);
 }
 
 .feature-card__icon {
@@ -198,6 +232,7 @@ a:hover {
   margin: 0;
   font-size: 1.3rem;
   font-weight: 600;
+  color: var(--color-primary);
 }
 
 .feature-card__description {
@@ -214,10 +249,12 @@ a:hover {
 }
 
 .curriculum-list li {
-  background-color: rgba(79, 70, 229, 0.08);
+  background: rgba(246, 193, 67, 0.18);
   border-radius: var(--radius-sm);
   padding: 1.15rem 1.25rem;
   font-weight: 500;
+  color: var(--color-primary-dark);
+  border: 1px solid rgba(246, 193, 67, 0.3);
 }
 
 .section__grid--testimonials {
@@ -228,10 +265,11 @@ a:hover {
   background-color: var(--color-surface);
   border-radius: var(--radius-md);
   padding: 2rem;
-  box-shadow: 0 10px 25px rgba(31, 41, 55, 0.08);
+  box-shadow: 0 16px 32px rgba(13, 59, 102, 0.08);
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
+  border: 1px solid rgba(13, 59, 102, 0.08);
 }
 
 .testimonial__quote {
@@ -248,6 +286,7 @@ a:hover {
 
 .testimonial__name {
   font-weight: 600;
+  color: var(--color-primary);
 }
 
 .testimonial__role {
@@ -263,7 +302,7 @@ a:hover {
   background-color: var(--color-surface);
   border-radius: var(--radius-md);
   padding: 2.25rem 2rem;
-  border: 1px solid rgba(79, 70, 229, 0.15);
+  border: 1px solid rgba(13, 59, 102, 0.15);
   display: flex;
   flex-direction: column;
   gap: 1.2rem;
@@ -271,11 +310,16 @@ a:hover {
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
+.pricing-tier:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 24px 40px rgba(13, 59, 102, 0.14);
+}
+
 .pricing-tier--highlight {
   border-color: transparent;
-  background: linear-gradient(160deg, rgba(79, 70, 229, 0.95), rgba(79, 70, 229, 0.8));
+  background: linear-gradient(160deg, rgba(13, 59, 102, 0.95), rgba(5, 36, 70, 0.92));
   color: #ffffff;
-  box-shadow: 0 20px 40px rgba(79, 70, 229, 0.25);
+  box-shadow: 0 28px 48px rgba(13, 59, 102, 0.2);
 }
 
 .pricing-tier--highlight .pricing-tier__description,
@@ -287,12 +331,19 @@ a:hover {
   margin: 0;
   font-size: 1.4rem;
   font-weight: 600;
+  color: var(--color-primary-dark);
+}
+
+.pricing-tier--highlight .pricing-tier__name,
+.pricing-tier--highlight .pricing-tier__price {
+  color: #ffffff;
 }
 
 .pricing-tier__price {
   margin: 0;
   font-size: 1.6rem;
   font-weight: 700;
+  color: var(--color-primary);
 }
 
 .pricing-tier__description {
@@ -309,42 +360,109 @@ a:hover {
   color: var(--color-muted);
 }
 
+.pricing-tier__features li::before {
+  content: '•';
+  color: var(--color-accent);
+  margin-right: 0.5rem;
+}
+
 .pricing-tier__cta {
   border: none;
   border-radius: 999px;
   padding: 0.75rem 1.6rem;
-  font-weight: 600;
+  font-weight: 700;
   cursor: pointer;
-
-  background-color: var(--color-primary);
-  color: #ffffff;
-  transition: background-color 0.2s ease, transform 0.3s ease, box-shadow 0.3s ease;
+  background: linear-gradient(135deg, var(--color-accent), #f8d46e);
+  color: var(--color-primary-dark);
+  transition: background 0.2s ease, transform 0.3s ease, box-shadow 0.3s ease;
+  box-shadow: 0 12px 26px rgba(246, 193, 67, 0.32);
 }
 
 .pricing-tier__cta:hover,
 .pricing-tier__cta:focus-visible {
-
-
-  transition: background-color 0.2s ease, transform 0.2s ease;
-}
-
-button:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 6px 14px rgba(0, 102, 255, 0.25);
-}
-
-.pricing-tier__cta:hover {
-
-  background-color: var(--color-primary-dark);
+  background: linear-gradient(135deg, #f8d46e, var(--color-accent));
   transform: translateY(-2px);
-  box-shadow: 0 14px 25px rgba(79, 70, 229, 0.25);
+  box-shadow: 0 16px 32px rgba(246, 193, 67, 0.42);
+}
+
+.section--contact {
+  background: rgba(255, 250, 240, 0.9);
+  border-radius: var(--radius-lg);
+  padding: 3rem clamp(1.5rem, 4vw, 3.5rem);
+  box-shadow: 0 16px 32px rgba(13, 59, 102, 0.08);
+  border: 1px solid rgba(246, 193, 67, 0.25);
+}
+
+.section--contact a {
+  color: var(--color-primary);
+  text-decoration: underline;
+}
+
+.section--cta {
+  background: linear-gradient(135deg, rgba(246, 193, 67, 0.92), rgba(255, 222, 134, 0.9));
+  border-radius: var(--radius-lg);
+  padding: 3rem clamp(1.5rem, 4vw, 3.5rem);
+  box-shadow: 0 22px 44px rgba(246, 193, 67, 0.25);
+  text-align: center;
+}
+
+.section--cta .section__header p {
+  color: rgba(15, 31, 47, 0.8);
+}
+
+.section--cta .hero__cta {
+  margin: 0 auto;
+}
+
+form {
+  background-color: var(--color-surface);
+  padding: 2.5rem 2rem;
+  border-radius: var(--radius-md);
+  box-shadow: 0 16px 32px rgba(13, 59, 102, 0.08);
+  display: grid;
+  gap: 1.5rem;
+  border: 1px solid rgba(13, 59, 102, 0.08);
+}
+
+form label {
+  display: block;
+  font-weight: 600;
+  color: var(--color-primary-dark);
+  margin-bottom: 0.5rem;
+}
+
+form input,
+form textarea {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(13, 59, 102, 0.25);
+  font-size: 1rem;
+  font-family: inherit;
+  background-color: #fff;
+  color: var(--color-text);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+form input:focus,
+form textarea:focus {
+  border-color: var(--color-accent);
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(246, 193, 67, 0.35);
+}
+
+.section--contact .contact-content p {
+  color: var(--color-text);
+}
+
+.section--contact .contact-content p:last-child {
+  margin-bottom: 0;
 }
 
 @media (max-width: 600px) {
   .homepage {
     padding: 3rem 1rem 4rem;
   }
-
 
   .hero {
     text-align: left;

--- a/beginner-react-webapp/src/App.test.js
+++ b/beginner-react-webapp/src/App.test.js
@@ -3,6 +3,6 @@ import App from './App';
 
 test("affiche l'accueil par défaut", () => {
   render(<App />);
-  const heading = screen.getByRole('heading', { name: /welcome to my first web app!/i });
+  const heading = screen.getByRole('heading', { name: /bienvenue sur codinglearn/i });
   expect(heading).toBeInTheDocument();
 });

--- a/beginner-react-webapp/src/HomePage.js
+++ b/beginner-react-webapp/src/HomePage.js
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import FeatureCard from './components/FeatureCard';
 import Testimonial from './components/Testimonial';
 import PricingTier from './components/PricingTier';
+import brandLogo from './assets/codinglearn-logo.svg';
 
 const HomePage = () => {
   const features = [
@@ -84,6 +85,9 @@ const HomePage = () => {
   return (
     <main className="homepage">
       <section className="hero" id="accueil">
+        <div className="hero__brand" aria-hidden="true">
+          <img src={brandLogo} alt="" />
+        </div>
         <h1>Bienvenue sur CodingLearn</h1>
         <p>
           La plateforme francophone qui transforme votre curiosité du code en

--- a/beginner-react-webapp/src/assets/codinglearn-logo.svg
+++ b/beginner-react-webapp/src/assets/codinglearn-logo.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 40" role="img" aria-labelledby="title desc">
+  <title id="title">Logo CodingLearn</title>
+  <desc id="desc">Monogramme stylisé représentant la lettre C ouverte entourant une étincelle dorée</desc>
+  <defs>
+    <linearGradient id="spark" x1="0%" x2="100%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#f6c143" />
+      <stop offset="100%" stop-color="#f8d46e" />
+    </linearGradient>
+  </defs>
+  <g fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+    <path
+      d="M24.5 31.2C16 31.2 9.2 24.3 9.2 15.8S16 0.4 24.5 0.4c4.7 0 9.1 1.8 12.5 5.1"
+      stroke="#0d3b66"
+      stroke-width="4.2"
+    />
+    <path
+      d="M22.3 11.2c-1.6 1.5-2.5 3.6-2.5 5.9 0 2.2 0.9 4.3 2.5 5.9 1.6 1.6 3.7 2.5 5.9 2.5 2.2 0 4.3-0.9 5.9-2.5"
+      stroke="#0d3b66"
+      stroke-width="2.8"
+      opacity="0.7"
+    />
+    <circle cx="38.5" cy="9.8" r="4.2" fill="url(#spark)" />
+    <path
+      d="M44.4 9.8h8.1"
+      stroke="#f6c143"
+      stroke-width="2"
+    />
+  </g>
+  <g transform="translate(56 8)" fill="#0f1f2f">
+    <path d="M6.2 23.4c-3.6 0-6.2-1.9-6.2-5.9V5.7h4.5v10.9c0 1.8 1 2.7 2.5 2.7s2.5-.9 2.5-2.7V5.7H14v11.8c0 4-2.6 5.9-7.8 5.9Z" />
+    <path d="M18.3 23V5.7h4.5V9c.9-2.2 2.7-3.6 5.3-3.6v4.6c-3.4 0-5.3 1.5-5.3 5V23h-4.5Z" />
+    <path d="M32.2 14.3c0-5.5 4-9.4 9.2-9.4 4.9 0 8.4 3.4 8.7 7.7h-4.4c-.3-2.1-1.9-3.6-4.3-3.6-2.8 0-4.6 2.2-4.6 5.3s1.8 5.3 4.6 5.3c2.4 0 4-1.5 4.3-3.6h4.4c-.3 4.3-3.9 7.7-8.7 7.7-5.2 0-9.2-3.9-9.2-9.4Z" />
+    <path d="M53.8 23V5.7h4.5v3c1-2.1 2.7-3.4 5.3-3.4 2.5 0 4.4 1.1 5.3 3.1 1.1-2 3.2-3.1 5.6-3.1 3.8 0 6.2 2.5 6.2 6.7V23h-4.5V12.7c0-1.9-1-3.1-2.8-3.1-1.9 0-3.1 1.4-3.1 3.5V23h-4.5V12.7c0-1.9-1-3.1-2.8-3.1-1.8 0-3.1 1.4-3.1 3.5V23h-4.5Z" />
+    <path d="M88.3 23V5.7h4.5V9c.9-2.2 2.7-3.6 5.3-3.6v4.6c-3.4 0-5.3 1.5-5.3 5V23h-4.5Z" />
+  </g>
+</svg>

--- a/beginner-react-webapp/src/components/NavBar.css
+++ b/beginner-react-webapp/src/components/NavBar.css
@@ -3,18 +3,46 @@
   align-items: center;
   justify-content: space-between;
   padding: 16px 32px;
-  background-color: #ffffff;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  background: linear-gradient(135deg, rgba(255, 250, 240, 0.95), rgba(247, 241, 223, 0.95));
+  border-bottom: 1px solid rgba(13, 59, 102, 0.1);
+  box-shadow: 0 10px 20px rgba(13, 59, 102, 0.08);
   position: sticky;
   top: 0;
   z-index: 100;
+  backdrop-filter: blur(10px);
 }
 
-.navbar__logo {
-  font-weight: 700;
-  font-size: 1.25rem;
-  color: #1a1a1a;
+.navbar__brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 800;
+  font-size: 1.35rem;
+  color: #0d3b66;
+  letter-spacing: 0.5px;
+  text-decoration: none;
+  transition: transform 0.2s ease;
+}
+
+.navbar__brand:hover,
+.navbar__brand:focus-visible {
+  transform: translateY(-2px);
+}
+
+.navbar__brand:focus-visible {
+  outline: 3px solid rgba(246, 193, 67, 0.55);
+  outline-offset: 4px;
+  border-radius: 999px;
+}
+
+.navbar__brand-mark {
+  width: 44px;
+  height: auto;
+  display: block;
+}
+
+.navbar__brand-text {
+  color: inherit;
 }
 
 .navbar__links {
@@ -26,35 +54,36 @@
 }
 
 .navbar__links a {
-  color: #1a1a1a;
+  color: #0f1f2f;
   text-decoration: none;
-  font-weight: 500;
-  transition: color 0.2s ease;
+  font-weight: 600;
+  transition: color 0.2s ease, transform 0.2s ease;
 }
 
 .navbar__links a:hover,
 .navbar__links a:focus {
-  color: #0066ff;
+  color: #f6c143;
+  transform: translateY(-2px);
 }
 
 .navbar__cta {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 10px 20px;
+  padding: 10px 22px;
   border-radius: 9999px;
-  background: linear-gradient(135deg, #0066ff, #2a8dff);
-  color: #ffffff;
-  font-weight: 600;
+  background: linear-gradient(135deg, #f6c143, #f8d46e);
+  color: #052446;
+  font-weight: 700;
   text-decoration: none;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
-  box-shadow: 0 4px 12px rgba(0, 102, 255, 0.25);
+  box-shadow: 0 12px 24px rgba(246, 193, 67, 0.35);
 }
 
 .navbar__cta:hover,
 .navbar__cta:focus {
-  transform: translateY(-1px);
-  box-shadow: 0 8px 18px rgba(0, 102, 255, 0.35);
+  transform: translateY(-2px);
+  box-shadow: 0 16px 28px rgba(246, 193, 67, 0.45);
 }
 
 @media (max-width: 768px) {
@@ -62,6 +91,10 @@
     flex-wrap: wrap;
     gap: 16px;
     padding: 16px 20px;
+  }
+
+  .navbar__brand {
+    order: -1;
   }
 
   .navbar__links {
@@ -82,8 +115,13 @@
     align-items: flex-start;
   }
 
-  .navbar__logo {
+  .navbar__brand {
     font-size: 1.1rem;
+    gap: 10px;
+  }
+
+  .navbar__brand-mark {
+    width: 38px;
   }
 
   .navbar__links {

--- a/beginner-react-webapp/src/components/NavBar.js
+++ b/beginner-react-webapp/src/components/NavBar.js
@@ -1,10 +1,14 @@
 import React from 'react';
+import brandLogo from '../assets/codinglearn-logo.svg';
 import './NavBar.css';
 
 const NavBar = () => {
   return (
     <nav className="navbar">
-      <div className="navbar__logo">CodingLearn</div>
+      <a className="navbar__brand" href="#accueil" aria-label="Revenir à l'accueil CodingLearn">
+        <img className="navbar__brand-mark" src={brandLogo} alt="Logo CodingLearn" />
+        <span className="navbar__brand-text">CodingLearn</span>
+      </a>
       <ul className="navbar__links">
         <li><a href="#accueil">Accueil</a></li>
         <li><a href="#parcours">Parcours</a></li>


### PR DESCRIPTION
## Summary
- add an accessible CodingLearn logo asset for reuse across the interface
- display the brand mark within the sticky navigation and hero header with updated styling
- enhance hero styling to showcase the logo while preserving the existing localized heading

## Testing
- CI=true npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68db07f84abc83339a37df36219ccbf2