### PR TITLE
Implement client-side authentication and dashboard experience

### DIFF
--- a/beginner-react-webapp/src/App.css
+++ b/beginner-react-webapp/src/App.css
@@ -463,3 +463,246 @@ form textarea:focus {
     padding: 32px 16px;
   }
 }
+
+.auth-page {
+  min-height: calc(100vh - 80px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem 1.5rem 4rem;
+  background: radial-gradient(circle at top right, rgba(13, 59, 102, 0.08), transparent 55%),
+    radial-gradient(circle at bottom left, rgba(246, 193, 67, 0.12), transparent 55%);
+}
+
+.auth-card {
+  background: var(--color-surface);
+  width: min(460px, 100%);
+  padding: clamp(1.75rem, 3vw, 2.5rem);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 20px 40px rgba(13, 59, 102, 0.12);
+}
+
+.auth-card h1 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+  color: var(--color-primary-dark);
+}
+
+.auth-card__subtitle {
+  margin-top: 0;
+  margin-bottom: 1.5rem;
+  color: var(--color-muted);
+}
+
+.auth-card__form {
+  background: transparent;
+  padding: 0;
+  border: none;
+  box-shadow: none;
+  display: grid;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.auth-card__form label {
+  font-weight: 600;
+  color: var(--color-primary);
+}
+
+.auth-card__form input,
+.auth-card__form select {
+  font: inherit;
+  padding: 0.75rem 0.85rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(13, 59, 102, 0.18);
+  background: #ffffff;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.auth-card__form input:focus,
+.auth-card__form select:focus {
+  border-color: rgba(13, 59, 102, 0.4);
+  box-shadow: 0 0 0 3px rgba(13, 59, 102, 0.08);
+  outline: none;
+}
+
+.auth-card__alert {
+  background: rgba(226, 68, 92, 0.1);
+  border: 1px solid rgba(226, 68, 92, 0.3);
+  color: #b3334a;
+  padding: 0.85rem 1rem;
+  border-radius: var(--radius-sm);
+  margin-bottom: 1.25rem;
+}
+
+.auth-card__footer {
+  margin: 0;
+  color: var(--color-muted);
+  text-align: center;
+}
+
+.auth-card__footer a {
+  color: var(--color-primary);
+}
+
+.dashboard {
+  padding: 3rem clamp(1.5rem, 4vw, 3rem);
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.dashboard__header h1 {
+  margin-bottom: 0.5rem;
+}
+
+.dashboard__header p {
+  margin: 0;
+  color: var(--color-muted);
+}
+
+.dashboard__summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.dashboard__card {
+  background: var(--color-surface);
+  border-radius: var(--radius-md);
+  padding: 1.5rem;
+  box-shadow: 0 18px 36px rgba(13, 59, 102, 0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.dashboard__card-label {
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+.dashboard__card-value {
+  font-size: 2rem;
+  color: var(--color-primary-dark);
+}
+
+.dashboard__progress-bar {
+  margin-top: 0.75rem;
+  background: rgba(13, 59, 102, 0.08);
+  border-radius: 999px;
+  height: 10px;
+  overflow: hidden;
+}
+
+.dashboard__progress-bar-fill {
+  height: 100%;
+  background: linear-gradient(135deg, var(--color-primary), #1f4f80);
+}
+
+.dashboard__modules {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.dashboard-module {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1.25rem;
+  padding: 1.75rem;
+  border-radius: var(--radius-md);
+  background: #ffffff;
+  box-shadow: 0 12px 28px rgba(13, 59, 102, 0.08);
+}
+
+.dashboard-module__content {
+  flex: 1;
+  min-width: min(320px, 100%);
+}
+
+.dashboard-module__content h2 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+}
+
+.dashboard-module__time {
+  margin-bottom: 0;
+  color: var(--color-muted);
+  font-weight: 600;
+}
+
+.dashboard-module__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  min-width: 220px;
+}
+
+.dashboard-module__actions label {
+  font-weight: 600;
+  color: var(--color-primary);
+}
+
+.dashboard-module__actions select {
+  font: inherit;
+  padding: 0.65rem 0.75rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(13, 59, 102, 0.2);
+  background: #fefcf5;
+}
+
+.dashboard-module__badge {
+  align-self: flex-start;
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.dashboard-module__badge--not_started {
+  background: rgba(13, 59, 102, 0.08);
+  color: #052446;
+}
+
+.dashboard-module__badge--in_progress {
+  background: rgba(246, 193, 67, 0.2);
+  color: #8a5a00;
+}
+
+.dashboard-module__badge--completed {
+  background: rgba(78, 178, 111, 0.2);
+  color: #21603b;
+}
+
+.dashboard__resources {
+  background: linear-gradient(135deg, rgba(255, 250, 240, 0.95), rgba(247, 241, 223, 0.9));
+  border-radius: var(--radius-lg);
+  padding: 2rem;
+  box-shadow: 0 12px 26px rgba(13, 59, 102, 0.08);
+}
+
+.dashboard__resources h2 {
+  margin-top: 0;
+}
+
+.dashboard__resources ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: var(--color-muted);
+  line-height: 1.7;
+}
+
+@media (max-width: 640px) {
+  .auth-card {
+    padding: 1.5rem;
+  }
+
+  .dashboard {
+    padding: 2.5rem 1.25rem;
+  }
+
+  .dashboard-module {
+    padding: 1.25rem;
+  }
+}

--- a/beginner-react-webapp/src/App.js
+++ b/beginner-react-webapp/src/App.js
@@ -2,21 +2,38 @@ import React from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import HomePage from './HomePage';
 import AboutPage from './AboutPage';
+import LoginPage from './LoginPage';
+import RegisterPage from './RegisterPage';
+import DashboardPage from './DashboardPage';
+import ProtectedRoute from './components/ProtectedRoute';
 import NavBar from './components/NavBar';
+import { AuthProvider } from './context/AuthContext';
 import './App.css';
 
 function App() {
   return (
     <Router>
-      <div className="App">
-        <NavBar />
-        <main>
-          <Routes>
-            <Route path="/" element={<HomePage />} />
-            <Route path="/about" element={<AboutPage />} />
-          </Routes>
-        </main>
-      </div>
+      <AuthProvider>
+        <div className="App">
+          <NavBar />
+          <main>
+            <Routes>
+              <Route path="/" element={<HomePage />} />
+              <Route path="/about" element={<AboutPage />} />
+              <Route path="/login" element={<LoginPage />} />
+              <Route path="/register" element={<RegisterPage />} />
+              <Route
+                path="/dashboard"
+                element={(
+                  <ProtectedRoute>
+                    <DashboardPage />
+                  </ProtectedRoute>
+                )}
+              />
+            </Routes>
+          </main>
+        </div>
+      </AuthProvider>
     </Router>
   );
 }

--- a/beginner-react-webapp/src/DashboardPage.js
+++ b/beginner-react-webapp/src/DashboardPage.js
@@ -1,0 +1,151 @@
+import React, { useMemo } from 'react';
+import { useAuth } from './context/AuthContext';
+
+const moduleDefinitions = [
+  {
+    id: 'onboarding',
+    title: 'Découverte & objectifs',
+    description:
+      'Comprendre la plateforme, définir vos objectifs et planifier vos premières semaines.',
+    estimatedTime: '45 minutes',
+  },
+  {
+    id: 'javascriptBasics',
+    title: 'Fondamentaux JavaScript',
+    description:
+      'Variables, fonctions, tableaux, objets et logique pour être à l’aise avec le langage.',
+    estimatedTime: '6 heures',
+  },
+  {
+    id: 'firstReactApp',
+    title: 'Votre première application React',
+    description:
+      'Créer des composants, gérer l’état et connecter vos interfaces à des données réelles.',
+    estimatedTime: '8 heures',
+  },
+  {
+    id: 'productionDeployment',
+    title: 'Mise en production & bonnes pratiques',
+    description: 'Optimiser, tester et déployer une application fiable en production.',
+    estimatedTime: '4 heures',
+  },
+];
+
+const statusLabels = {
+  not_started: 'Non commencé',
+  in_progress: 'En cours',
+  completed: 'Terminé',
+};
+
+const DashboardPage = () => {
+  const { user, updateProgress } = useAuth();
+
+  const statistics = useMemo(() => {
+    const totalModules = moduleDefinitions.length;
+    const statusList = moduleDefinitions.map((module) => user?.progress?.[module.id] ?? 'not_started');
+    const completed = statusList.filter((status) => status === 'completed').length;
+    const inProgress = statusList.filter((status) => status === 'in_progress').length;
+
+    return {
+      totalModules,
+      completed,
+      inProgress,
+      completionRate: Math.round((completed / totalModules) * 100),
+    };
+  }, [user?.progress]);
+
+  const handleStatusChange = (moduleId, event) => {
+    updateProgress(moduleId, event.target.value);
+  };
+
+  const formattedLastLogin = user?.lastLoginAt
+    ? new Date(user.lastLoginAt).toLocaleString('fr-FR', {
+        day: '2-digit',
+        month: 'long',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+      })
+    : '—';
+
+  return (
+    <div className="dashboard">
+      <header className="dashboard__header">
+        <h1>Bonjour {user?.fullName ?? 'apprenant·e'}</h1>
+        <p>
+          Programme <strong>{user?.cohort}</strong> · Dernière connexion : {formattedLastLogin}
+        </p>
+      </header>
+
+      <section className="dashboard__summary" aria-label="Statistiques de progression">
+        <div className="dashboard__card">
+          <span className="dashboard__card-label">Modules complétés</span>
+          <strong className="dashboard__card-value">{statistics.completed}</strong>
+        </div>
+        <div className="dashboard__card">
+          <span className="dashboard__card-label">Modules en cours</span>
+          <strong className="dashboard__card-value">{statistics.inProgress}</strong>
+        </div>
+        <div className="dashboard__card">
+          <span className="dashboard__card-label">Progression globale</span>
+          <strong className="dashboard__card-value">{statistics.completionRate}%</strong>
+          <div
+            className="dashboard__progress-bar"
+            role="progressbar"
+            aria-valuenow={statistics.completionRate}
+            aria-valuemin="0"
+            aria-valuemax="100"
+          >
+            <div
+              className="dashboard__progress-bar-fill"
+              style={{ width: `${statistics.completionRate}%` }}
+            />
+          </div>
+        </div>
+      </section>
+
+      <section className="dashboard__modules" aria-label="Modules du parcours">
+        {moduleDefinitions.map((module) => {
+          const currentStatus = user?.progress?.[module.id] ?? 'not_started';
+          return (
+            <article key={module.id} className="dashboard-module">
+              <div className="dashboard-module__content">
+                <h2>{module.title}</h2>
+                <p>{module.description}</p>
+                <p className="dashboard-module__time">⏱ {module.estimatedTime}</p>
+              </div>
+              <div className="dashboard-module__actions">
+                <label htmlFor={`status-${module.id}`}>Statut</label>
+                <select
+                  id={`status-${module.id}`}
+                  value={currentStatus}
+                  onChange={(event) => handleStatusChange(module.id, event)}
+                >
+                  {Object.entries(statusLabels).map(([value, label]) => (
+                    <option value={value} key={value}>
+                      {label}
+                    </option>
+                  ))}
+                </select>
+                <span className={`dashboard-module__badge dashboard-module__badge--${currentStatus}`}>
+                  {statusLabels[currentStatus]}
+                </span>
+              </div>
+            </article>
+          );
+        })}
+      </section>
+
+      <section className="dashboard__resources" aria-label="Ressources complémentaires">
+        <h2>Prochaines actions</h2>
+        <ul>
+          <li>Participez à la session live de coaching ce jeudi à 18h (UTC+1).</li>
+          <li>Déposez votre premier mini-projet pour recevoir un feedback personnalisé.</li>
+          <li>Rejoignez le salon Discord de votre cohorte pour échanger avec la communauté.</li>
+        </ul>
+      </section>
+    </div>
+  );
+};
+
+export default DashboardPage;

--- a/beginner-react-webapp/src/HomePage.js
+++ b/beginner-react-webapp/src/HomePage.js
@@ -89,8 +89,8 @@ const HomePage = () => {
           La plateforme francophone qui transforme votre curiosité du code en
           compétences concrètes.
         </p>
-        <Link to="/about" className="hero__cta">
-          En savoir plus
+        <Link to="/register" className="hero__cta">
+          Créer mon compte gratuit
         </Link>
       </section>
 
@@ -171,7 +171,7 @@ const HomePage = () => {
           <h2 id="signup-heading">Prêt·e à vous lancer&nbsp;?</h2>
           <p>Créez votre compte et commencez votre premier module gratuitement.</p>
         </div>
-        <Link className="hero__cta" to="/about">
+        <Link className="hero__cta" to="/register">
           Je m’inscris maintenant
         </Link>
       </section>

--- a/beginner-react-webapp/src/LoginPage.js
+++ b/beginner-react-webapp/src/LoginPage.js
@@ -1,0 +1,93 @@
+import React, { useEffect, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useAuth } from './context/AuthContext';
+
+const LoginPage = () => {
+  const navigate = useNavigate();
+  const { login, authError, clearError, user } = useAuth();
+  const [formValues, setFormValues] = useState({ email: '', password: '' });
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    clearError();
+    return () => clearError();
+  }, [clearError]);
+
+  useEffect(() => {
+    if (user) {
+      navigate('/dashboard', { replace: true });
+    }
+  }, [navigate, user]);
+
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+    setFormValues((current) => ({ ...current, [name]: value }));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setIsSubmitting(true);
+    const success = await login(formValues.email, formValues.password);
+    setIsSubmitting(false);
+
+    if (success) {
+      navigate('/dashboard', { replace: true });
+    }
+  };
+
+  return (
+    <div className="auth-page">
+      <div className="auth-card" role="form">
+        <h1>Connexion</h1>
+        <p className="auth-card__subtitle">
+          Retrouvez vos parcours personnalisés et reprenez votre progression.
+        </p>
+
+        {authError ? (
+          <div className="auth-card__alert" role="alert">
+            {authError}
+          </div>
+        ) : null}
+
+        <form onSubmit={handleSubmit} className="auth-card__form">
+          <label htmlFor="email">Adresse email</label>
+          <input
+            id="email"
+            name="email"
+            type="email"
+            autoComplete="email"
+            placeholder="vous@exemple.com"
+            value={formValues.email}
+            onChange={handleChange}
+            required
+          />
+
+          <label htmlFor="password">Mot de passe</label>
+          <input
+            id="password"
+            name="password"
+            type="password"
+            autoComplete="current-password"
+            placeholder="Votre mot de passe"
+            value={formValues.password}
+            onChange={handleChange}
+            required
+          />
+
+          <button type="submit" disabled={isSubmitting}>
+            {isSubmitting ? 'Connexion en cours…' : 'Se connecter'}
+          </button>
+        </form>
+
+        <p className="auth-card__footer">
+          Pas encore de compte ?{' '}
+          <Link to="/register" onClick={clearError}>
+            Créer un compte
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default LoginPage;

--- a/beginner-react-webapp/src/RegisterPage.js
+++ b/beginner-react-webapp/src/RegisterPage.js
@@ -1,0 +1,121 @@
+import React, { useEffect, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useAuth } from './context/AuthContext';
+
+const cohorts = ['Débutant', 'Intensif', 'Reconversion', 'Entrepreneuriat'];
+
+const RegisterPage = () => {
+  const navigate = useNavigate();
+  const { register, authError, clearError, user } = useAuth();
+  const [formValues, setFormValues] = useState({
+    fullName: '',
+    email: '',
+    password: '',
+    cohort: cohorts[0],
+  });
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    clearError();
+    return () => clearError();
+  }, [clearError]);
+
+  useEffect(() => {
+    if (user) {
+      navigate('/dashboard', { replace: true });
+    }
+  }, [navigate, user]);
+
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+    setFormValues((current) => ({ ...current, [name]: value }));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setIsSubmitting(true);
+    const success = await register(formValues);
+    setIsSubmitting(false);
+
+    if (success) {
+      navigate('/dashboard', { replace: true });
+    }
+  };
+
+  return (
+    <div className="auth-page">
+      <div className="auth-card" role="form">
+        <h1>Créer votre compte</h1>
+        <p className="auth-card__subtitle">
+          Définissez votre parcours et recevez un accompagnement adapté à vos objectifs.
+        </p>
+
+        {authError ? (
+          <div className="auth-card__alert" role="alert">
+            {authError}
+          </div>
+        ) : null}
+
+        <form onSubmit={handleSubmit} className="auth-card__form">
+          <label htmlFor="fullName">Nom complet</label>
+          <input
+            id="fullName"
+            name="fullName"
+            type="text"
+            placeholder="Ex. Aïcha Diallo"
+            value={formValues.fullName}
+            onChange={handleChange}
+            required
+          />
+
+          <label htmlFor="email">Adresse email</label>
+          <input
+            id="email"
+            name="email"
+            type="email"
+            placeholder="vous@exemple.com"
+            autoComplete="email"
+            value={formValues.email}
+            onChange={handleChange}
+            required
+          />
+
+          <label htmlFor="password">Mot de passe</label>
+          <input
+            id="password"
+            name="password"
+            type="password"
+            placeholder="Au moins 6 caractères"
+            autoComplete="new-password"
+            minLength={6}
+            value={formValues.password}
+            onChange={handleChange}
+            required
+          />
+
+          <label htmlFor="cohort">Programme</label>
+          <select id="cohort" name="cohort" value={formValues.cohort} onChange={handleChange}>
+            {cohorts.map((cohort) => (
+              <option value={cohort} key={cohort}>
+                {cohort}
+              </option>
+            ))}
+          </select>
+
+          <button type="submit" disabled={isSubmitting}>
+            {isSubmitting ? 'Création du compte…' : "Je m'inscris"}
+          </button>
+        </form>
+
+        <p className="auth-card__footer">
+          Vous avez déjà un compte ?{' '}
+          <Link to="/login" onClick={clearError}>
+            Se connecter
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default RegisterPage;

--- a/beginner-react-webapp/src/components/NavBar.css
+++ b/beginner-react-webapp/src/components/NavBar.css
@@ -17,6 +17,7 @@
   font-size: 1.35rem;
   color: #0d3b66;
   letter-spacing: 0.5px;
+  text-decoration: none;
 }
 
 .navbar__links {
@@ -34,10 +35,32 @@
   transition: color 0.2s ease, transform 0.2s ease;
 }
 
+.navbar__links a.active {
+  color: #0d3b66;
+}
+
 .navbar__links a:hover,
 .navbar__links a:focus {
   color: #f6c143;
   transform: translateY(-2px);
+}
+
+.navbar__actions {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.navbar__link {
+  color: #0f1f2f;
+  font-weight: 600;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.navbar__link:hover,
+.navbar__link:focus {
+  color: #f6c143;
 }
 
 .navbar__cta {
@@ -60,6 +83,24 @@
   box-shadow: 0 16px 28px rgba(246, 193, 67, 0.45);
 }
 
+.navbar__logout {
+  background: transparent;
+  border: 1px solid rgba(13, 59, 102, 0.2);
+  color: #052446;
+  padding: 8px 16px;
+  border-radius: 9999px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.navbar__logout:hover,
+.navbar__logout:focus {
+  background: rgba(13, 59, 102, 0.08);
+  color: #052446;
+  transform: translateY(-1px);
+}
+
 @media (max-width: 768px) {
   .navbar {
     flex-wrap: wrap;
@@ -74,9 +115,18 @@
     gap: 12px 16px;
   }
 
-  .navbar__cta {
+  .navbar__actions {
     width: 100%;
-    padding: 12px 24px;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 12px;
+  }
+
+  .navbar__cta,
+  .navbar__logout,
+  .navbar__link {
+    width: 100%;
+    text-align: center;
   }
 }
 

--- a/beginner-react-webapp/src/components/NavBar.js
+++ b/beginner-react-webapp/src/components/NavBar.js
@@ -1,17 +1,62 @@
 import React from 'react';
+import { Link, NavLink, useNavigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
 import './NavBar.css';
 
 const NavBar = () => {
+  const navigate = useNavigate();
+  const { user, logout } = useAuth();
+
+  const handleLogout = () => {
+    logout();
+    navigate('/', { replace: true });
+  };
+
   return (
     <nav className="navbar">
-      <div className="navbar__logo">CodingLearn</div>
+      <Link className="navbar__logo" to="/">
+        CodingLearn
+      </Link>
       <ul className="navbar__links">
-        <li><a href="#accueil">Accueil</a></li>
-        <li><a href="#parcours">Parcours</a></li>
-        <li><a href="#tarifs">Tarifs</a></li>
-        <li><a href="#contact">Contact</a></li>
+        <li>
+          <NavLink to="/" end>
+            Accueil
+          </NavLink>
+        </li>
+        <li>
+          <Link to="/#parcours">Parcours</Link>
+        </li>
+        <li>
+          <Link to="/#tarifs">Tarifs</Link>
+        </li>
+        <li>
+          <Link to="/#contact">Contact</Link>
+        </li>
+        <li>
+          <NavLink to="/about">À propos</NavLink>
+        </li>
       </ul>
-      <a className="navbar__cta" href="#signup">Commencer gratuitement</a>
+      <div className="navbar__actions">
+        {user ? (
+          <>
+            <NavLink className="navbar__link" to="/dashboard">
+              Tableau de bord
+            </NavLink>
+            <button type="button" className="navbar__logout" onClick={handleLogout}>
+              Se déconnecter
+            </button>
+          </>
+        ) : (
+          <>
+            <NavLink className="navbar__link" to="/login">
+              Se connecter
+            </NavLink>
+            <NavLink className="navbar__cta" to="/register">
+              Commencer gratuitement
+            </NavLink>
+          </>
+        )}
+      </div>
     </nav>
   );
 };

--- a/beginner-react-webapp/src/components/ProtectedRoute.js
+++ b/beginner-react-webapp/src/components/ProtectedRoute.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+
+const ProtectedRoute = ({ children }) => {
+  const { user } = useAuth();
+
+  if (!user) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return children;
+};
+
+export default ProtectedRoute;

--- a/beginner-react-webapp/src/context/AuthContext.js
+++ b/beginner-react-webapp/src/context/AuthContext.js
@@ -1,0 +1,191 @@
+import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
+
+const USERS_KEY = 'codinglearn:users';
+const ACTIVE_USER_KEY = 'codinglearn:active-user';
+
+const defaultProgress = {
+  onboarding: 'not_started',
+  javascriptBasics: 'not_started',
+  firstReactApp: 'not_started',
+  productionDeployment: 'not_started',
+};
+
+const AuthContext = createContext();
+
+const isBrowser = () => typeof window !== 'undefined' && !!window.localStorage;
+
+const readStorage = (key, fallback) => {
+  if (!isBrowser()) {
+    return fallback;
+  }
+
+  try {
+    const rawValue = window.localStorage.getItem(key);
+    return rawValue ? JSON.parse(rawValue) : fallback;
+  } catch (error) {
+    console.warn('Unable to read storage key', key, error);
+    return fallback;
+  }
+};
+
+const writeStorage = (key, value) => {
+  if (!isBrowser()) {
+    return;
+  }
+
+  try {
+    if (value === undefined || value === null) {
+      window.localStorage.removeItem(key);
+      return;
+    }
+
+    window.localStorage.setItem(key, JSON.stringify(value));
+  } catch (error) {
+    console.warn('Unable to write storage key', key, error);
+  }
+};
+
+const loadUsers = () => readStorage(USERS_KEY, []);
+const persistUsers = (users) => writeStorage(USERS_KEY, users);
+const persistActiveUser = (user) => writeStorage(ACTIVE_USER_KEY, user);
+
+export const AuthProvider = ({ children }) => {
+  const [user, setUser] = useState(() => readStorage(ACTIVE_USER_KEY, null));
+  const [authError, setAuthError] = useState(null);
+
+  const syncActiveUser = useCallback((nextUser) => {
+    setUser(nextUser);
+    persistActiveUser(nextUser);
+  }, []);
+
+  const register = useCallback(({ fullName, email, password, cohort }) => {
+    const trimmedName = fullName?.trim();
+    const trimmedEmail = email?.trim().toLowerCase();
+    const trimmedPassword = password?.trim();
+
+    if (!trimmedName || !trimmedEmail || !trimmedPassword) {
+      setAuthError('Merci de renseigner votre nom, email et mot de passe.');
+      return false;
+    }
+
+    const users = loadUsers();
+    const userAlreadyExists = users.some((existingUser) => existingUser.email === trimmedEmail);
+
+    if (userAlreadyExists) {
+      setAuthError('Un compte existe déjà avec cet email.');
+      return false;
+    }
+
+    const newUser = {
+      fullName: trimmedName,
+      email: trimmedEmail,
+      password: trimmedPassword,
+      cohort: cohort || 'Débutant',
+      role: 'Apprenant·e',
+      progress: { ...defaultProgress },
+      lastLoginAt: new Date().toISOString(),
+    };
+
+    persistUsers([...users, newUser]);
+    syncActiveUser(newUser);
+    setAuthError(null);
+    return true;
+  }, [syncActiveUser]);
+
+  const login = useCallback((email, password) => {
+    const trimmedEmail = email?.trim().toLowerCase();
+    const trimmedPassword = password?.trim();
+
+    if (!trimmedEmail || !trimmedPassword) {
+      setAuthError('Veuillez renseigner votre email et votre mot de passe.');
+      return false;
+    }
+
+    const users = loadUsers();
+    const existingUser = users.find(
+      (storedUser) => storedUser.email === trimmedEmail && storedUser.password === trimmedPassword,
+    );
+
+    if (!existingUser) {
+      setAuthError('Identifiants invalides. Vérifiez votre email ou votre mot de passe.');
+      return false;
+    }
+
+    const updatedUser = {
+      ...existingUser,
+      lastLoginAt: new Date().toISOString(),
+    };
+
+    const updatedUsers = users.map((storedUser) =>
+      storedUser.email === updatedUser.email ? updatedUser : storedUser,
+    );
+
+    persistUsers(updatedUsers);
+    syncActiveUser(updatedUser);
+    setAuthError(null);
+    return true;
+  }, [syncActiveUser]);
+
+  const logout = useCallback(() => {
+    syncActiveUser(null);
+    setAuthError(null);
+  }, [syncActiveUser]);
+
+  const updateProgress = useCallback((moduleKey, status) => {
+    setUser((currentUser) => {
+      if (!currentUser) {
+        return currentUser;
+      }
+
+      const safeStatus = ['not_started', 'in_progress', 'completed'].includes(status)
+        ? status
+        : 'not_started';
+
+      const nextUser = {
+        ...currentUser,
+        progress: {
+          ...currentUser.progress,
+          [moduleKey]: safeStatus,
+        },
+      };
+
+      persistActiveUser(nextUser);
+
+      const users = loadUsers();
+      const updatedUsers = users.map((storedUser) =>
+        storedUser.email === nextUser.email ? { ...nextUser, password: storedUser.password } : storedUser,
+      );
+
+      persistUsers(updatedUsers);
+      return nextUser;
+    });
+  }, []);
+
+  const clearError = useCallback(() => setAuthError(null), []);
+
+  const value = useMemo(
+    () => ({
+      user,
+      authError,
+      login,
+      logout,
+      register,
+      updateProgress,
+      clearError,
+    }),
+    [authError, login, logout, register, updateProgress, user, clearError],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+
+  if (!context) {
+    throw new Error('useAuth doit être utilisé à l’intérieur d’un AuthProvider');
+  }
+
+  return context;
+};
+


### PR DESCRIPTION
## Summary
- add a client-side authentication context with local persistence and protected routes
- implement login, registration, and dashboard pages with progress management
- refresh the navigation and styling to integrate the new authenticated experience

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db107b39888333b92c8d828c63c2c2