### PR TITLE
feat: renforcer la navigation et l’expérience tableau de bord

### DIFF
--- a/beginner-react-webapp/src/App.css
+++ b/beginner-react-webapp/src/App.css
@@ -12,6 +12,17 @@
   --radius-sm: 8px;
 }
 
+:root[data-theme='dark'] {
+  --color-primary: #6aa9ff;
+  --color-primary-dark: #d6e4ff;
+  --color-accent: #f6c143;
+  --color-background: #08111f;
+  --color-surface: #101d32;
+  --color-text: #f4f7ff;
+  --color-muted: #9bb1ca;
+  --shadow-soft: 0 22px 46px rgba(3, 9, 18, 0.65);
+}
+
 * {
   box-sizing: border-box;
 }
@@ -598,6 +609,122 @@ form textarea:focus {
 
 .dashboard {
   padding: 3rem clamp(1.5rem, 4vw, 3rem);
+  display: grid;
+  grid-template-columns: minmax(220px, 280px) minmax(0, 1fr);
+  gap: 2.5rem;
+  align-items: start;
+}
+
+.dashboard__sidebar {
+  position: sticky;
+  top: 180px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  background: var(--color-surface);
+  border-radius: var(--radius-md);
+  padding: 1.75rem 1.5rem;
+  box-shadow: 0 18px 32px rgba(13, 59, 102, 0.12);
+}
+
+[data-theme='dark'] .dashboard__sidebar {
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.55);
+}
+
+.dashboard__sidebar-profile {
+  display: flex;
+  gap: 0.85rem;
+  align-items: center;
+}
+
+.dashboard__sidebar-avatar {
+  width: 48px;
+  height: 48px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  color: var(--color-primary-dark);
+  background: rgba(13, 59, 102, 0.12);
+}
+
+[data-theme='dark'] .dashboard__sidebar-avatar {
+  background: rgba(106, 169, 255, 0.2);
+  color: var(--color-primary-dark);
+}
+
+.dashboard__sidebar-name {
+  margin: 0;
+  font-weight: 600;
+}
+
+.dashboard__sidebar-cohort {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.85rem;
+}
+
+.dashboard__sidebar nav ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.dashboard__sidebar nav a {
+  color: var(--color-muted);
+  font-weight: 600;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.dashboard__sidebar nav a:hover,
+.dashboard__sidebar nav a:focus {
+  color: var(--color-primary);
+}
+
+.dashboard__sidebar-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.dashboard__sidebar-button {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.35rem;
+  border: 1px solid rgba(13, 59, 102, 0.15);
+  border-radius: var(--radius-sm);
+  background: rgba(13, 59, 102, 0.06);
+  color: inherit;
+  padding: 0.75rem 1rem;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.dashboard__sidebar-button:hover,
+.dashboard__sidebar-button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 20px rgba(13, 59, 102, 0.18);
+  outline: none;
+}
+
+[data-theme='dark'] .dashboard__sidebar-button {
+  background: rgba(16, 29, 50, 0.8);
+  border-color: rgba(106, 169, 255, 0.25);
+}
+
+.dashboard__sidebar-button small {
+  color: var(--color-muted);
+  font-size: 0.75rem;
+}
+
+.dashboard__content {
   display: flex;
   flex-direction: column;
   gap: 2.5rem;
@@ -704,7 +831,7 @@ form textarea:focus {
 }
 
 .dashboard__panel {
-  background: #ffffff;
+  background: var(--color-surface);
   border-radius: var(--radius-md);
   box-shadow: 0 14px 28px rgba(13, 59, 102, 0.08);
   padding: 1.75rem;
@@ -905,7 +1032,7 @@ form textarea:focus {
   gap: 1.25rem;
   padding: 1.75rem;
   border-radius: var(--radius-md);
-  background: #ffffff;
+  background: var(--color-surface);
   box-shadow: 0 12px 28px rgba(13, 59, 102, 0.08);
 }
 
@@ -1006,6 +1133,65 @@ form textarea:focus {
   color: var(--color-muted);
 }
 
+.dashboard__feedback {
+  background: rgba(246, 193, 67, 0.18);
+  border: 1px solid rgba(246, 193, 67, 0.35);
+  color: #5a4300;
+  padding: 0.85rem 1.1rem;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+}
+
+[data-theme='dark'] .dashboard__feedback {
+  background: rgba(246, 193, 67, 0.2);
+  border-color: rgba(246, 193, 67, 0.35);
+  color: #f9f3dc;
+}
+
+.dashboard__module-filter {
+  display: grid;
+  gap: 0.45rem;
+  margin-top: 1rem;
+  max-width: 420px;
+}
+
+.dashboard__module-filter label {
+  font-weight: 600;
+  color: var(--color-primary);
+}
+
+.dashboard__module-filter input {
+  font: inherit;
+  padding: 0.65rem 0.75rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(13, 59, 102, 0.2);
+  background: #ffffff;
+}
+
+.dashboard__module-filter input:focus {
+  outline: none;
+  border-color: rgba(13, 59, 102, 0.45);
+  box-shadow: 0 0 0 3px rgba(13, 59, 102, 0.15);
+}
+
+[data-theme='dark'] .dashboard__module-filter input {
+  background: rgba(16, 29, 50, 0.9);
+  border-color: rgba(106, 169, 255, 0.35);
+  color: var(--color-text);
+}
+
+.dashboard__empty {
+  background: rgba(13, 59, 102, 0.05);
+  padding: 1rem 1.25rem;
+  border-radius: var(--radius-sm);
+  margin: 0;
+  color: var(--color-muted);
+}
+
+[data-theme='dark'] .dashboard__empty {
+  background: rgba(16, 29, 50, 0.6);
+}
+
 .dashboard__resources {
   background: linear-gradient(135deg, rgba(255, 250, 240, 0.95), rgba(247, 241, 223, 0.9));
   border-radius: var(--radius-lg);
@@ -1020,7 +1206,7 @@ form textarea:focus {
 }
 
 .dashboard-resource {
-  background: rgba(255, 255, 255, 0.85);
+  background: var(--color-surface);
   border-radius: var(--radius-md);
   padding: 1.25rem;
   display: flex;
@@ -1038,7 +1224,7 @@ form textarea:focus {
 }
 
 .dashboard__support {
-  background: #ffffff;
+  background: var(--color-surface);
   border-radius: var(--radius-lg);
   padding: 2rem;
   box-shadow: 0 12px 28px rgba(13, 59, 102, 0.08);
@@ -1068,6 +1254,351 @@ form textarea:focus {
   color: var(--color-muted);
 }
 
+[data-theme='dark'] .dashboard__card,
+[data-theme='dark'] .dashboard__panel,
+[data-theme='dark'] .dashboard-module,
+[data-theme='dark'] .dashboard-resource,
+[data-theme='dark'] .dashboard__support {
+  box-shadow: 0 18px 38px rgba(0, 0, 0, 0.55);
+}
+
+[data-theme='dark'] .dashboard__resources {
+  background: linear-gradient(135deg, rgba(16, 29, 50, 0.95), rgba(9, 18, 32, 0.95));
+}
+
+[data-theme='dark'] .dashboard-resource__type {
+  color: var(--color-primary-dark);
+}
+
+.profile,
+.settings,
+.help {
+  padding: 3rem clamp(1.5rem, 4vw, 3rem);
+  max-width: 1100px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.profile__header,
+.settings__header,
+.help__header {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  padding: 2rem clamp(1.25rem, 3vw, 2.5rem);
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+}
+
+.profile__identity {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+}
+
+.profile__avatar {
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, rgba(13, 59, 102, 0.18), rgba(246, 193, 67, 0.32));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: var(--color-primary);
+}
+
+.profile__role,
+.profile__meta {
+  margin: 0;
+  color: var(--color-muted);
+}
+
+.profile__actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.profile__button,
+.settings__submit {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.7rem 1.4rem;
+  border-radius: 999px;
+  font-weight: 600;
+  border: none;
+  background: linear-gradient(135deg, var(--color-primary), #1f4f80);
+  color: #ffffff;
+  cursor: pointer;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 14px 26px rgba(13, 59, 102, 0.18);
+}
+
+.profile__button:hover,
+.profile__button:focus,
+.settings__submit:hover,
+.settings__submit:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 32px rgba(13, 59, 102, 0.25);
+}
+
+.profile__button--secondary {
+  background: rgba(13, 59, 102, 0.1);
+  color: var(--color-primary);
+}
+
+.profile__button--ghost {
+  background: transparent;
+  border: 1px solid rgba(13, 59, 102, 0.2);
+  color: var(--color-primary);
+  box-shadow: none;
+}
+
+.profile__section {
+  display: grid;
+  gap: 1.5rem;
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  padding: 1.75rem;
+  box-shadow: 0 14px 28px rgba(13, 59, 102, 0.08);
+}
+
+.profile__details {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem 1.5rem;
+  margin: 0;
+}
+
+.profile__details div {
+  background: rgba(13, 59, 102, 0.05);
+  padding: 0.85rem 1rem;
+  border-radius: var(--radius-sm);
+}
+
+.profile__details dt {
+  font-weight: 600;
+  margin-bottom: 0.35rem;
+}
+
+.profile__details dd {
+  margin: 0;
+}
+
+.profile__summary {
+  background: rgba(246, 193, 67, 0.15);
+  border-radius: var(--radius-md);
+  padding: 1.25rem;
+}
+
+.profile__summary ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.profile__activity {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.profile__activity li {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  background: rgba(13, 59, 102, 0.05);
+  border-radius: var(--radius-md);
+  padding: 1rem 1.25rem;
+}
+
+.profile__activity-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 90px;
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: var(--color-primary);
+  background: rgba(13, 59, 102, 0.12);
+  border-radius: 999px;
+  padding: 0.45rem 0.85rem;
+}
+
+.profile__activity-badge.is-complete {
+  color: #1f6f3d;
+  background: rgba(78, 178, 111, 0.2);
+}
+
+.profile__support-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+}
+
+.profile__support-grid article {
+  background: rgba(13, 59, 102, 0.05);
+  border-radius: var(--radius-md);
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.settings__header p,
+.help__header p {
+  max-width: 540px;
+  margin: 0;
+  color: var(--color-muted);
+}
+
+.settings__meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.35rem;
+  color: var(--color-muted);
+}
+
+.settings__feedback {
+  background: rgba(106, 169, 255, 0.18);
+  border: 1px solid rgba(106, 169, 255, 0.35);
+  color: #074b8e;
+  padding: 0.85rem 1.1rem;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+}
+
+.settings__form {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  padding: 2rem;
+  display: grid;
+  gap: 1.5rem;
+  box-shadow: 0 14px 28px rgba(13, 59, 102, 0.08);
+}
+
+.settings__form fieldset {
+  border: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.85rem;
+}
+
+.settings__form legend {
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: var(--color-primary);
+}
+
+.settings__toggle,
+.settings__option {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  background: rgba(13, 59, 102, 0.06);
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius-sm);
+}
+
+.settings__toggle input,
+.settings__option input {
+  width: 1.1rem;
+  height: 1.1rem;
+  accent-color: var(--color-primary);
+}
+
+.settings__select {
+  font-weight: 600;
+  color: var(--color-primary);
+}
+
+.settings__form select {
+  font: inherit;
+  padding: 0.65rem 0.75rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(13, 59, 102, 0.2);
+}
+
+.help__section {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  padding: 1.75rem;
+  box-shadow: 0 12px 24px rgba(13, 59, 102, 0.08);
+  display: grid;
+  gap: 1rem;
+}
+
+.help__section details {
+  background: rgba(13, 59, 102, 0.05);
+  border-radius: var(--radius-sm);
+  padding: 0.75rem 1rem;
+}
+
+.help__section summary {
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.help__cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.help__cards article {
+  background: rgba(13, 59, 102, 0.05);
+  border-radius: var(--radius-md);
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.help__links {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.help__links a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.5rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid rgba(13, 59, 102, 0.2);
+}
+
+[data-theme='dark'] .profile__summary,
+[data-theme='dark'] .profile__details div,
+[data-theme='dark'] .profile__activity li,
+[data-theme='dark'] .profile__support-grid article,
+[data-theme='dark'] .settings__toggle,
+[data-theme='dark'] .settings__option,
+[data-theme='dark'] .help__section details,
+[data-theme='dark'] .help__cards article {
+  background: rgba(16, 29, 50, 0.7);
+  border-color: rgba(106, 169, 255, 0.15);
+}
+
 .sr-only {
   position: absolute;
   width: 1px;
@@ -1080,12 +1611,38 @@ form textarea:focus {
   border: 0;
 }
 
+@media (max-width: 1024px) {
+  .dashboard {
+    grid-template-columns: 1fr;
+  }
+
+  .dashboard__sidebar {
+    position: static;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 1rem;
+  }
+
+  .dashboard__sidebar-actions {
+    flex: 1 1 100%;
+  }
+
+  .dashboard__sidebar nav ul {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 0.75rem 1rem;
+  }
+}
+
 @media (max-width: 640px) {
   .auth-card {
     padding: 1.5rem;
   }
 
-  .dashboard {
+  .dashboard,
+  .profile,
+  .settings,
+  .help {
     padding: 2.5rem 1.25rem;
   }
 
@@ -1103,5 +1660,31 @@ form textarea:focus {
 
   .dashboard-task-form {
     grid-template-columns: 1fr;
+  }
+
+  .dashboard__sidebar {
+    position: static;
+    padding: 1.25rem;
+  }
+
+  .dashboard__sidebar nav ul {
+    flex-direction: column;
+  }
+
+  .profile__header,
+  .settings__header,
+  .help__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .profile__identity {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .profile__activity li {
+    flex-direction: column;
+    align-items: flex-start;
   }
 }

--- a/beginner-react-webapp/src/App.js
+++ b/beginner-react-webapp/src/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import HomePage from './HomePage';
 import AboutPage from './AboutPage';
@@ -7,32 +7,81 @@ import RegisterPage from './RegisterPage';
 import DashboardPage from './DashboardPage';
 import ProtectedRoute from './components/ProtectedRoute';
 import NavBar from './components/NavBar';
+import Breadcrumbs from './components/Breadcrumbs';
 import { AuthProvider } from './context/AuthContext';
+import ProfilePage from './ProfilePage';
+import SettingsPage from './SettingsPage';
+import HelpPage from './HelpPage';
 import './App.css';
+
+const THEME_STORAGE_KEY = 'codinglearn:theme-preference';
+
+const AppShell = () => {
+  const [theme, setTheme] = useState(() => {
+    if (typeof window === 'undefined') {
+      return 'light';
+    }
+
+    return window.localStorage.getItem(THEME_STORAGE_KEY) || 'light';
+  });
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = theme;
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+    }
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme((current) => (current === 'dark' ? 'light' : 'dark'));
+  };
+
+  return (
+    <div className="App" data-theme={theme}>
+      <NavBar onToggleTheme={toggleTheme} theme={theme} />
+      <Breadcrumbs />
+      <main id="main-content">
+        <Routes>
+          <Route path="/" element={<HomePage />} />
+          <Route path="/about" element={<AboutPage />} />
+          <Route path="/help" element={<HelpPage />} />
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/register" element={<RegisterPage />} />
+          <Route
+            path="/dashboard"
+            element={(
+              <ProtectedRoute>
+                <DashboardPage />
+              </ProtectedRoute>
+            )}
+          />
+          <Route
+            path="/profile"
+            element={(
+              <ProtectedRoute>
+                <ProfilePage />
+              </ProtectedRoute>
+            )}
+          />
+          <Route
+            path="/settings"
+            element={(
+              <ProtectedRoute>
+                <SettingsPage />
+              </ProtectedRoute>
+            )}
+          />
+        </Routes>
+      </main>
+    </div>
+  );
+};
 
 function App() {
   return (
     <Router>
       <AuthProvider>
-        <div className="App">
-          <NavBar />
-          <main>
-            <Routes>
-              <Route path="/" element={<HomePage />} />
-              <Route path="/about" element={<AboutPage />} />
-              <Route path="/login" element={<LoginPage />} />
-              <Route path="/register" element={<RegisterPage />} />
-              <Route
-                path="/dashboard"
-                element={(
-                  <ProtectedRoute>
-                    <DashboardPage />
-                  </ProtectedRoute>
-                )}
-              />
-            </Routes>
-          </main>
-        </div>
+        <AppShell />
       </AuthProvider>
     </Router>
   );

--- a/beginner-react-webapp/src/HelpPage.js
+++ b/beginner-react-webapp/src/HelpPage.js
@@ -1,0 +1,70 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+const HelpPage = () => (
+  <div className="help" aria-labelledby="help-heading">
+    <header className="help__header">
+      <h1 id="help-heading">Centre d’aide CodingLearn</h1>
+      <p>Retrouvez les réponses aux questions fréquentes et contactez notre équipe en quelques clics.</p>
+    </header>
+
+    <section className="help__section" aria-labelledby="help-faq">
+      <h2 id="help-faq">Questions fréquentes</h2>
+      <details>
+        <summary>Comment accéder à mon tableau de bord ?</summary>
+        <p>Connectez-vous, puis cliquez sur « Tableau de bord » dans la navigation principale.</p>
+      </details>
+      <details>
+        <summary>Où modifier mes informations personnelles ?</summary>
+        <p>
+          Rendez-vous sur la page <Link to="/settings">Paramètres</Link> pour mettre à jour vos coordonnées, préférences et
+          confidentialité.
+        </p>
+      </details>
+      <details>
+        <summary>Comment contacter mon mentor ?</summary>
+        <p>
+          Les coordonnées de votre mentor sont disponibles dans votre <Link to="/dashboard">tableau de bord</Link> et dans la
+          page <Link to="/profile">Profil</Link>.
+        </p>
+      </details>
+    </section>
+
+    <section className="help__section" aria-labelledby="help-contact">
+      <h2 id="help-contact">Nous contacter</h2>
+      <div className="help__cards">
+        <article>
+          <h3>Support pédagogique</h3>
+          <p>Email : <a href="mailto:mentor@codinglearn.io">mentor@codinglearn.io</a></p>
+          <p>Disponibilité : du lundi au vendredi, 9h-17h</p>
+        </article>
+        <article>
+          <h3>Support technique</h3>
+          <p>Email : <a href="mailto:support@codinglearn.io">support@codinglearn.io</a></p>
+          <p>Temps de réponse moyen : 24h ouvrées</p>
+        </article>
+        <article>
+          <h3>Communauté</h3>
+          <p>Rejoignez le Discord dans la section « Communauté » de votre tableau de bord.</p>
+        </article>
+      </div>
+    </section>
+
+    <section className="help__section" aria-labelledby="help-shortcuts">
+      <h2 id="help-shortcuts">Raccourcis utiles</h2>
+      <ul className="help__links">
+        <li>
+          <Link to="/dashboard">Ouvrir le tableau de bord</Link>
+        </li>
+        <li>
+          <Link to="/profile">Voir mon profil</Link>
+        </li>
+        <li>
+          <Link to="/settings">Mettre à jour mes paramètres</Link>
+        </li>
+      </ul>
+    </section>
+  </div>
+);
+
+export default HelpPage;

--- a/beginner-react-webapp/src/ProfilePage.js
+++ b/beginner-react-webapp/src/ProfilePage.js
@@ -1,0 +1,168 @@
+import React, { useMemo } from 'react';
+import { Link } from 'react-router-dom';
+import { useAuth } from './context/AuthContext';
+
+const getInitials = (fullName = '') => {
+  const [first = '', second = ''] = fullName.split(' ');
+  return `${first.charAt(0)}${second.charAt(0)}`.toUpperCase() || 'CL';
+};
+
+const ProfilePage = () => {
+  const { user } = useAuth();
+
+  const progressOverview = useMemo(() => {
+    const progress = user?.progress ?? {};
+    const total = Object.keys(progress).length || 0;
+    const completed = Object.values(progress).filter((status) => status === 'completed').length;
+    const inProgress = Object.values(progress).filter((status) => status === 'in_progress').length;
+
+    return {
+      total,
+      completed,
+      inProgress,
+    };
+  }, [user?.progress]);
+
+  const lastActivities = useMemo(() => {
+    const tasks = user?.dashboard?.tasks ?? [];
+    return tasks
+      .slice(-4)
+      .reverse()
+      .map((task) => ({
+        id: task.id,
+        label: task.label,
+        completed: task.completed,
+        category: task.category,
+      }));
+  }, [user?.dashboard?.tasks]);
+
+  return (
+    <div className="profile" aria-labelledby="profile-heading">
+      <header className="profile__header">
+        <div className="profile__identity">
+          <div className="profile__avatar" aria-hidden="true">
+            {getInitials(user?.fullName)}
+          </div>
+          <div>
+            <h1 id="profile-heading">{user?.fullName}</h1>
+            <p className="profile__role">{user?.role ?? 'Apprenant·e CodingLearn'}</p>
+            <p className="profile__meta">Promotion {user?.cohort}</p>
+          </div>
+        </div>
+        <div className="profile__actions">
+          <Link className="profile__button" to="/settings">
+            Modifier mon profil
+          </Link>
+          <a className="profile__button profile__button--secondary" href="mailto:support@codinglearn.io">
+            Contacter le support
+          </a>
+        </div>
+      </header>
+
+      <section className="profile__section" aria-labelledby="profile-infos">
+        <div>
+          <h2 id="profile-infos">Informations personnelles</h2>
+          <dl className="profile__details">
+            <div>
+              <dt>Nom complet</dt>
+              <dd>{user?.fullName}</dd>
+            </div>
+            <div>
+              <dt>Email</dt>
+              <dd>
+                <a href={`mailto:${user?.email}`}>{user?.email}</a>
+              </dd>
+            </div>
+            <div>
+              <dt>Date d'inscription</dt>
+              <dd>
+                {user?.createdAt
+                  ? new Date(user.createdAt).toLocaleDateString('fr-FR', {
+                      year: 'numeric',
+                      month: 'long',
+                      day: '2-digit',
+                    })
+                  : '—'}
+              </dd>
+            </div>
+            <div>
+              <dt>Progression</dt>
+              <dd>
+                {progressOverview.completed} modules terminés · {progressOverview.inProgress} en cours ·{' '}
+                {Math.max(progressOverview.total - progressOverview.completed - progressOverview.inProgress, 0)} restant(s)
+              </dd>
+            </div>
+          </dl>
+        </div>
+        <aside className="profile__summary" aria-labelledby="profile-highlight">
+          <h2 id="profile-highlight">Résumé express</h2>
+          <ul>
+            <li>
+              Dernière connexion :{' '}
+              {user?.lastLoginAt
+                ? new Date(user.lastLoginAt).toLocaleString('fr-FR', {
+                    day: '2-digit',
+                    month: 'long',
+                    hour: '2-digit',
+                    minute: '2-digit',
+                  })
+                : '—'}
+            </li>
+            <li>Série actuelle : {user?.streakCount ?? 1} jour(s)</li>
+            <li>Objectif de la semaine : {user?.dashboard?.learningGoal?.focus ?? 'Non défini'}</li>
+          </ul>
+        </aside>
+      </section>
+
+      <section className="profile__section" aria-labelledby="profile-activity">
+        <h2 id="profile-activity">Historique récent</h2>
+        <ul className="profile__activity">
+          {lastActivities.length === 0 ? (
+            <li>Aucune activité enregistrée pour le moment.</li>
+          ) : (
+            lastActivities.map((activity) => (
+              <li key={activity.id}>
+                <span className={`profile__activity-badge ${activity.completed ? 'is-complete' : ''}`}>
+                  {activity.completed ? 'Terminé' : 'À faire'}
+                </span>
+                <div>
+                  <p>{activity.label}</p>
+                  <small>{activity.category}</small>
+                </div>
+              </li>
+            ))
+          )}
+        </ul>
+      </section>
+
+      <section className="profile__section" aria-labelledby="profile-support">
+        <h2 id="profile-support">Contacts utiles</h2>
+        <div className="profile__support-grid">
+          <article>
+            <h3>Mentor pédagogique</h3>
+            <p>Nina Martin</p>
+            <a className="profile__button profile__button--ghost" href="mailto:mentor@codinglearn.io">
+              Écrire à Nina
+            </a>
+          </article>
+          <article>
+            <h3>Coach carrière</h3>
+            <p>Alex Dupont</p>
+            <a className="profile__button profile__button--ghost" href="mailto:career@codinglearn.io">
+              Planifier un rendez-vous
+            </a>
+          </article>
+          <article>
+            <h3>Support technique</h3>
+            <p>Équipe CodingLearn</p>
+            <a className="profile__button profile__button--ghost" href="mailto:support@codinglearn.io">
+              Ouvrir un ticket
+            </a>
+          </article>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default ProfilePage;

--- a/beginner-react-webapp/src/SettingsPage.js
+++ b/beginner-react-webapp/src/SettingsPage.js
@@ -1,0 +1,118 @@
+import React, { useEffect, useState } from 'react';
+import { useAuth } from './context/AuthContext';
+
+const initialSettings = {
+  weeklySummary: true,
+  reminders: true,
+  visibility: 'private',
+  language: 'fr',
+};
+
+const SettingsPage = () => {
+  const { user } = useAuth();
+  const [settings, setSettings] = useState(initialSettings);
+  const [feedback, setFeedback] = useState(null);
+
+  useEffect(() => {
+    const browserLanguage = typeof navigator !== 'undefined' ? navigator.language : 'fr';
+    setSettings((previous) => ({
+      ...previous,
+      language: browserLanguage?.startsWith('en') ? 'en' : 'fr',
+    }));
+  }, []);
+
+  const handleChange = (event) => {
+    const { name, type, value, checked } = event.target;
+    setSettings((current) => ({
+      ...current,
+      [name]: type === 'checkbox' ? checked : value,
+    }));
+  };
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    setFeedback('Vos préférences ont été enregistrées avec succès.');
+    setTimeout(() => setFeedback(null), 4500);
+  };
+
+  return (
+    <div className="settings" aria-labelledby="settings-heading">
+      <header className="settings__header">
+        <div>
+          <h1 id="settings-heading">Paramètres du compte</h1>
+          <p>Mettez à jour vos préférences de communication et de confidentialité.</p>
+        </div>
+        <div className="settings__meta">
+          <span>Connecté en tant que</span>
+          <strong>{user?.email}</strong>
+        </div>
+      </header>
+
+      {feedback && (
+        <div className="settings__feedback" role="status" aria-live="polite">
+          {feedback}
+        </div>
+      )}
+
+      <form className="settings__form" onSubmit={handleSubmit}>
+        <fieldset>
+          <legend>Notifications</legend>
+          <label className="settings__toggle">
+            <input
+              type="checkbox"
+              name="weeklySummary"
+              checked={settings.weeklySummary}
+              onChange={handleChange}
+            />
+            <span>Recevoir le récapitulatif hebdomadaire</span>
+          </label>
+          <label className="settings__toggle">
+            <input type="checkbox" name="reminders" checked={settings.reminders} onChange={handleChange} />
+            <span>Activer les rappels de coaching et d’échéance</span>
+          </label>
+        </fieldset>
+
+        <fieldset>
+          <legend>Confidentialité</legend>
+          <label className="settings__option">
+            <input
+              type="radio"
+              name="visibility"
+              value="private"
+              checked={settings.visibility === 'private'}
+              onChange={handleChange}
+            />
+            <span>Profil visible uniquement par l’équipe pédagogique</span>
+          </label>
+          <label className="settings__option">
+            <input
+              type="radio"
+              name="visibility"
+              value="cohort"
+              checked={settings.visibility === 'cohort'}
+              onChange={handleChange}
+            />
+            <span>Partager mes avancées avec ma promotion</span>
+          </label>
+        </fieldset>
+
+        <fieldset>
+          <legend>Préférences d’affichage</legend>
+          <label className="settings__select" htmlFor="language">
+            Langue de l’interface
+          </label>
+          <select id="language" name="language" value={settings.language} onChange={handleChange}>
+            <option value="fr">Français</option>
+            <option value="en">Anglais</option>
+          </select>
+        </fieldset>
+
+        <button type="submit" className="settings__submit">
+          Enregistrer les modifications
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default SettingsPage;

--- a/beginner-react-webapp/src/components/Breadcrumbs.css
+++ b/beginner-react-webapp/src/components/Breadcrumbs.css
@@ -1,0 +1,94 @@
+.breadcrumbs-wrapper {
+  background: rgba(255, 255, 255, 0.7);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(13, 59, 102, 0.08);
+  position: sticky;
+  top: 72px;
+  z-index: 90;
+}
+
+[data-theme='dark'] .breadcrumbs-wrapper {
+  background: rgba(10, 18, 32, 0.7);
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
+.breadcrumbs {
+  margin: 0 auto;
+  max-width: 1200px;
+  padding: 0.75rem 1.5rem;
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.breadcrumbs__back {
+  border: none;
+  background: transparent;
+  color: var(--color-primary);
+  font-weight: 600;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: var(--radius-sm);
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.breadcrumbs__back:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.breadcrumbs__back:not(:disabled):hover,
+.breadcrumbs__back:not(:disabled):focus-visible {
+  background: rgba(13, 59, 102, 0.08);
+  color: var(--color-primary-dark);
+}
+
+.breadcrumbs__nav ol {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+}
+
+.breadcrumbs__nav a {
+  color: var(--color-muted);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.breadcrumbs__nav a:hover,
+.breadcrumbs__nav a:focus {
+  color: var(--color-primary);
+}
+
+.breadcrumbs__nav span[aria-current='page'] {
+  font-weight: 700;
+  color: var(--color-primary-dark);
+}
+
+[data-theme='dark'] .breadcrumbs__nav span[aria-current='page'] {
+  color: var(--color-accent);
+}
+
+.breadcrumbs__separator {
+  color: var(--color-muted);
+  padding: 0 0.25rem;
+}
+
+@media (max-width: 768px) {
+  .breadcrumbs-wrapper {
+    top: 68px;
+  }
+
+  .breadcrumbs {
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    padding: 0.6rem 1rem;
+  }
+}

--- a/beginner-react-webapp/src/components/Breadcrumbs.js
+++ b/beginner-react-webapp/src/components/Breadcrumbs.js
@@ -1,0 +1,85 @@
+import React, { useMemo } from 'react';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
+import './Breadcrumbs.css';
+
+const breadcrumbLabels = {
+  '/': 'Accueil',
+  '/about': 'À propos',
+  '/dashboard': 'Tableau de bord',
+  '/profile': 'Profil',
+  '/settings': 'Paramètres',
+  '/help': 'Aide',
+  '/login': 'Connexion',
+  '/register': 'Inscription',
+};
+
+const normalisePath = (path) => (path.length > 1 && path.endsWith('/') ? path.slice(0, -1) : path);
+
+const Breadcrumbs = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const canGoBack = typeof window !== 'undefined' ? window.history.length > 1 : false;
+
+  const crumbs = useMemo(() => {
+    const pathname = normalisePath(location.pathname);
+    if (pathname === '/') {
+      return [
+        {
+          path: '/',
+          label: breadcrumbLabels['/'],
+          isCurrent: true,
+        },
+      ];
+    }
+
+    const segments = pathname.split('/').filter(Boolean);
+    const mappedSegments = segments.map((segment, index) => {
+      const path = `/${segments.slice(0, index + 1).join('/')}`;
+      return {
+        path,
+        label: breadcrumbLabels[path] || segment.replace(/-/g, ' '),
+        isCurrent: index === segments.length - 1,
+      };
+    });
+
+    return [
+      {
+        path: '/',
+        label: breadcrumbLabels['/'],
+        isCurrent: false,
+      },
+      ...mappedSegments,
+    ];
+  }, [location.pathname]);
+
+  return (
+    <div className="breadcrumbs-wrapper" role="presentation">
+      <div className="breadcrumbs">
+        <button
+          type="button"
+          className="breadcrumbs__back"
+          onClick={() => navigate(-1)}
+          disabled={!canGoBack || location.pathname === '/'}
+        >
+          ← Retour
+        </button>
+        <nav aria-label="Fil d'Ariane" className="breadcrumbs__nav">
+          <ol>
+            {crumbs.map((crumb, index) => (
+              <li key={crumb.path}>
+                {crumb.isCurrent ? (
+                  <span aria-current="page">{crumb.label}</span>
+                ) : (
+                  <Link to={crumb.path}>{crumb.label}</Link>
+                )}
+                {index < crumbs.length - 1 && <span className="breadcrumbs__separator">/</span>}
+              </li>
+            ))}
+          </ol>
+        </nav>
+      </div>
+    </div>
+  );
+};
+
+export default Breadcrumbs;

--- a/beginner-react-webapp/src/components/NavBar.css
+++ b/beginner-react-webapp/src/components/NavBar.css
@@ -2,7 +2,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 16px 32px;
+  padding: 1rem 2rem;
   background: linear-gradient(135deg, rgba(255, 250, 240, 0.95), rgba(247, 241, 223, 0.95));
   border-bottom: 1px solid rgba(13, 59, 102, 0.1);
   box-shadow: 0 10px 20px rgba(13, 59, 102, 0.08);
@@ -12,21 +12,26 @@
   backdrop-filter: blur(10px);
 }
 
+[data-theme='dark'] .navbar {
+  background: linear-gradient(135deg, rgba(13, 24, 40, 0.92), rgba(6, 13, 26, 0.92));
+  border-bottom-color: rgba(255, 255, 255, 0.08);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
+}
 
 .navbar__brand {
   display: inline-flex;
   align-items: center;
-  gap: 12px;
-
-.navbar__logo {
-
+  gap: 0.75rem;
   font-weight: 800;
   font-size: 1.35rem;
-  color: #0d3b66;
+  color: var(--color-primary-dark);
   letter-spacing: 0.5px;
   text-decoration: none;
-
   transition: transform 0.2s ease;
+}
+
+[data-theme='dark'] .navbar__brand {
+  color: #f7f5ff;
 }
 
 .navbar__brand:hover,
@@ -48,13 +53,12 @@
 
 .navbar__brand-text {
   color: inherit;
-
 }
 
 .navbar__links {
   display: flex;
   list-style: none;
-  gap: 24px;
+  gap: 1.25rem;
   padding: 0;
   margin: 0;
 }
@@ -64,25 +68,34 @@
   text-decoration: none;
   font-weight: 600;
   transition: color 0.2s ease, transform 0.2s ease;
-
+  padding: 0.35rem 0.5rem;
+  border-radius: var(--radius-sm);
 }
 
 .navbar__links a.active {
-  color: #0d3b66;
-
+  color: var(--color-primary);
+  background: rgba(13, 59, 102, 0.08);
 }
 
 .navbar__links a:hover,
 .navbar__links a:focus {
-  color: #f6c143;
+  color: var(--color-accent);
   transform: translateY(-2px);
+}
 
+[data-theme='dark'] .navbar__links a {
+  color: #d7e0f0;
+}
+
+[data-theme='dark'] .navbar__links a.active {
+  background: rgba(246, 193, 67, 0.12);
+  color: var(--color-accent);
 }
 
 .navbar__actions {
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: 1rem;
 }
 
 .navbar__link {
@@ -94,14 +107,18 @@
 
 .navbar__link:hover,
 .navbar__link:focus {
+  color: var(--color-accent);
+}
 
+[data-theme='dark'] .navbar__link {
+  color: #d7e0f0;
 }
 
 .navbar__cta {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 10px 22px;
+  padding: 0.6rem 1.25rem;
   border-radius: 9999px;
   background: linear-gradient(135deg, #f6c143, #f8d46e);
   color: #052446;
@@ -115,14 +132,13 @@
 .navbar__cta:focus {
   transform: translateY(-2px);
   box-shadow: 0 16px 28px rgba(246, 193, 67, 0.45);
-
 }
 
 .navbar__logout {
   background: transparent;
   border: 1px solid rgba(13, 59, 102, 0.2);
   color: #052446;
-  padding: 8px 16px;
+  padding: 0.55rem 1.1rem;
   border-radius: 9999px;
   font-weight: 600;
   cursor: pointer;
@@ -134,66 +150,88 @@
   background: rgba(13, 59, 102, 0.08);
   color: #052446;
   transform: translateY(-1px);
-
 }
 
-@media (max-width: 768px) {
+[data-theme='dark'] .navbar__logout {
+  border-color: rgba(255, 255, 255, 0.28);
+  color: #f5f8ff;
+}
+
+[data-theme='dark'] .navbar__logout:hover,
+[data-theme='dark'] .navbar__logout:focus {
+  background: rgba(246, 193, 67, 0.14);
+  color: var(--color-accent);
+}
+
+.navbar__theme-toggle {
+  border: 1px solid transparent;
+  background: rgba(13, 59, 102, 0.08);
+  color: var(--color-primary-dark);
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.navbar__theme-toggle:hover,
+.navbar__theme-toggle:focus-visible {
+  background: rgba(246, 193, 67, 0.2);
+  transform: translateY(-1px);
+}
+
+[data-theme='dark'] .navbar__theme-toggle {
+  background: rgba(246, 193, 67, 0.12);
+  color: #f7f5ff;
+  border-color: rgba(246, 193, 67, 0.4);
+}
+
+[data-theme='dark'] .navbar__theme-toggle:hover,
+[data-theme='dark'] .navbar__theme-toggle:focus-visible {
+  background: rgba(246, 193, 67, 0.25);
+}
+
+@media (max-width: 1024px) {
   .navbar {
     flex-wrap: wrap;
-    gap: 16px;
-    padding: 16px 20px;
-  }
-
-  .navbar__brand {
-    order: -1;
+    gap: 1rem;
+    padding: 1rem 1.5rem;
   }
 
   .navbar__links {
+    order: 1;
     width: 100%;
-    justify-content: space-between;
+    justify-content: center;
     flex-wrap: wrap;
-    gap: 12px 16px;
   }
 
   .navbar__actions {
     width: 100%;
-    justify-content: space-between;
+    justify-content: flex-end;
     flex-wrap: wrap;
-    gap: 12px;
-  }
-
-  .navbar__cta,
-  .navbar__logout,
-  .navbar__link {
-    width: 100%;
-    text-align: center;
   }
 }
 
-@media (max-width: 480px) {
+@media (max-width: 768px) {
   .navbar {
     align-items: flex-start;
   }
 
-  .navbar__brand {
-    font-size: 1.1rem;
-    gap: 10px;
-  }
-
-  .navbar__brand-mark {
-    width: 38px;
-  }
-
   .navbar__links {
-    flex-direction: column;
-    align-items: flex-start;
+    justify-content: flex-start;
+    gap: 0.75rem;
   }
 
-  .navbar__links a {
+  .navbar__actions {
+    justify-content: flex-start;
+    gap: 0.75rem;
+  }
+
+  .navbar__link,
+  .navbar__cta,
+  .navbar__logout,
+  .navbar__theme-toggle {
     width: 100%;
-  }
-
-  .navbar__cta {
-    font-size: 1rem;
+    text-align: center;
   }
 }

--- a/beginner-react-webapp/src/components/NavBar.js
+++ b/beginner-react-webapp/src/components/NavBar.js
@@ -5,10 +5,21 @@ import brandLogo from '../assets/codinglearn-logo.svg';
 
 import './NavBar.css';
 
-const NavBar = () => {
+const navLinks = [
+  { to: '/', label: 'Accueil', end: true },
+  { to: '/dashboard', label: 'Tableau de bord', protected: true },
+  { to: '/profile', label: 'Profil', protected: true },
+  { to: '/settings', label: 'Paramètres', protected: true },
+  { to: '/help', label: 'Aide' },
+  { to: '/about', label: 'À propos' },
+];
+
+const NavBar = ({ onToggleTheme = () => {}, theme = 'light' }) => {
   const navigate = useNavigate();
   const { user, logout } = useAuth();
-  const LinkComponent = NavLink ?? Link;
+  const isNavLinkAvailable = typeof NavLink === 'function' || (typeof NavLink === 'object' && NavLink !== null);
+  const LinkComponent = isNavLinkAvailable ? NavLink : Link;
+  const navLinkClassName = isNavLinkAvailable ? ({ isActive }) => (isActive ? 'active' : undefined) : undefined;
 
   const handleLogout = () => {
     logout();
@@ -16,52 +27,47 @@ const NavBar = () => {
   };
 
   return (
-    <nav className="navbar">
-
-      <a className="navbar__brand" href="#accueil" aria-label="Revenir à l'accueil CodingLearn">
+    <nav className="navbar" aria-label="Navigation principale">
+      <LinkComponent
+        className="navbar__brand"
+        to="/"
+        aria-label="Revenir à l'accueil CodingLearn"
+        {...(isNavLinkAvailable ? { end: true } : {})}
+      >
         <img className="navbar__brand-mark" src={brandLogo} alt="Logo CodingLearn" />
         <span className="navbar__brand-text">CodingLearn</span>
-      </a>
-
-      <Link className="navbar__logo" to="/">
-        CodingLearn
-      </Link>
+      </LinkComponent>
 
       <ul className="navbar__links">
-        <li>
-          <LinkComponent to="/" {...(NavLink ? { end: true } : {})}>
-            Accueil
-          </LinkComponent>
-        </li>
-        <li>
-          <Link to="/#parcours">Parcours</Link>
-        </li>
-        <li>
-          <Link to="/#tarifs">Tarifs</Link>
-        </li>
-        <li>
-          <Link to="/#contact">Contact</Link>
-        </li>
-        <li>
-          <LinkComponent to="/about">À propos</LinkComponent>
-        </li>
+        {navLinks
+          .filter((item) => !item.protected || user)
+          .map(({ to, label, end }) => (
+            <li key={to}>
+              <LinkComponent to={to} {...(isNavLinkAvailable && end ? { end: true } : {})} className={navLinkClassName}>
+                {label}
+              </LinkComponent>
+            </li>
+          ))}
       </ul>
       <div className="navbar__actions">
+        <button
+          type="button"
+          className="navbar__theme-toggle"
+          onClick={onToggleTheme}
+          aria-pressed={theme === 'dark'}
+        >
+          {theme === 'dark' ? 'Mode clair' : 'Mode sombre'}
+        </button>
         {user ? (
-          <>
-            <LinkComponent className="navbar__link" to="/dashboard">
-              Tableau de bord
-            </LinkComponent>
-            <button type="button" className="navbar__logout" onClick={handleLogout}>
-              Se déconnecter
-            </button>
-          </>
+          <button type="button" className="navbar__logout" onClick={handleLogout}>
+            Se déconnecter
+          </button>
         ) : (
           <>
-            <LinkComponent className="navbar__link" to="/login">
+            <LinkComponent className="navbar__link" to="/login" {...(isNavLinkAvailable ? { end: true } : {})}>
               Se connecter
             </LinkComponent>
-            <LinkComponent className="navbar__cta" to="/register">
+            <LinkComponent className="navbar__cta" to="/register" {...(isNavLinkAvailable ? { end: true } : {})}>
               Commencer gratuitement
             </LinkComponent>
           </>

--- a/beginner-react-webapp/src/setupTests.js
+++ b/beginner-react-webapp/src/setupTests.js
@@ -10,19 +10,27 @@ jest.mock(
     const React = require('react');
 
     const PassThrough = ({ children }) => <div>{children}</div>;
+    const Anchor = React.forwardRef(({ to, children, className, end, ...rest }, ref) => (
+      <a
+        href={typeof to === 'string' ? to : '#'}
+        ref={ref}
+        className={typeof className === 'function' ? className({ isActive: false }) : className}
+        {...rest}
+      >
+        {children}
+      </a>
+    ));
 
     return {
       __esModule: true,
-      Link: ({ to, children, ...rest }) => (
-        <a href={typeof to === 'string' ? to : '#'} {...rest}>
-          {children}
-        </a>
-      ),
+      Link: Anchor,
+      NavLink: Anchor,
       MemoryRouter: PassThrough,
       BrowserRouter: PassThrough,
       Routes: PassThrough,
       Route: ({ element }) => element,
       useNavigate: () => () => {},
+      useLocation: () => ({ pathname: '/', search: '', hash: '', state: null, key: 'mock' }),
     };
   },
   { virtual: true }


### PR DESCRIPTION
## Summary
- add a theme-aware layout shell with persistent breadcrumbs and new help/profile/settings routes
- redesign the dashboard with a sidebar, quick actions, live feedback and module filtering
- add dedicated profile, settings and help pages plus update styling and router test mocks

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68e6ee5f9ca083338e1ee32e0ad7ff1a